### PR TITLE
Increase writing time delay

### DIFF
--- a/serialEEPROM.cpp
+++ b/serialEEPROM.cpp
@@ -93,7 +93,7 @@ void serialEEPROM::write(uint16_t memaddress, uint8_t*  src, int len)
     else
     {
       /* Delay ~3.5 ms to ensure byte write */
-      delay(4);    
+      delay(5);
     }
   }
 }


### PR DESCRIPTION
Add 1ms to the  writing delay to give EEPROM a break in order to end writing